### PR TITLE
iguana: add environment variables for ROOT and clas12root support

### DIFF
--- a/modulefiles/iguana/.common
+++ b/modulefiles/iguana/.common
@@ -13,10 +13,9 @@ set d [home]/[osrelease]/local/iguana/$version/$v
 
 warndir $d "iguana/$version is not available for hipo/$v"
 
+setenv IGUANA $d
 prepend-path PATH $d/bin
 prepend-path LD_LIBRARY_PATH $d/lib
 prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
 prepend-path PYTHONPATH $d/python
-setenv IGUANA_FORTRAN_LIBS "-L$d/lib -lIguanaAlgorithms -lIguanaFortran"
-setenv IGUANA_FORTRAN_FLAGS "-I$d/lib/iguana"
-
+prepend-path ROOT_INCLUDE_PATH $d/include

--- a/modulefiles/iguana/0.4.1
+++ b/modulefiles/iguana/0.4.1
@@ -12,10 +12,9 @@ set d [home]/[osrelease]/local/iguana/$version/$v
 
 warndir $d "iguana/$version is not available for hipo/$v"
 
+setenv IGUANA $d
 prepend-path PATH $d/bin
 prepend-path LD_LIBRARY_PATH $d/lib
 prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
 prepend-path PYTHONPATH $d/python
-setenv IGUANA_FORTRAN_LIBS "-L$d/lib -lIguanaAlgorithms -lIguanaFortran"
-setenv IGUANA_FORTRAN_FLAGS "-I$d/lib/iguana"
-
+prepend-path ROOT_INCLUDE_PATH $d/include

--- a/modulefiles/iguana/0.5.0
+++ b/modulefiles/iguana/0.5.0
@@ -12,10 +12,9 @@ set d [home]/[osrelease]/local/iguana/$version/$v
 
 warndir $d "iguana/$version is not available for hipo/$v"
 
+setenv IGUANA $d
 prepend-path PATH $d/bin
 prepend-path LD_LIBRARY_PATH $d/lib
 prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
 prepend-path PYTHONPATH $d/python
-setenv IGUANA_FORTRAN_LIBS "-L$d/lib -lIguanaAlgorithms -lIguanaFortran"
-setenv IGUANA_FORTRAN_FLAGS "-I$d/lib/iguana"
-
+prepend-path ROOT_INCLUDE_PATH $d/include

--- a/modulefiles/iguana/0.6.0
+++ b/modulefiles/iguana/0.6.0
@@ -12,10 +12,9 @@ set d [home]/[osrelease]/local/iguana/$version/$v
 
 warndir $d "iguana/$version is not available for hipo/$v"
 
+setenv IGUANA $d
 prepend-path PATH $d/bin
 prepend-path LD_LIBRARY_PATH $d/lib
 prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
 prepend-path PYTHONPATH $d/python
-setenv IGUANA_FORTRAN_LIBS "-L$d/lib -lIguanaAlgorithms -lIguanaFortran"
-setenv IGUANA_FORTRAN_FLAGS "-I$d/lib/iguana"
-
+prepend-path ROOT_INCLUDE_PATH $d/include


### PR DESCRIPTION
Supports:
- https://github.com/JeffersonLab/iguana/pull/210
- https://github.com/JeffersonLab/clas12root/pull/69

| Variable                                                 | Modification                                                                                                                              |
| ---                                                      | ---                                                                                                                                       |
| `ROOT_INCLUDE_PATH`                                      | Iguana header files, for usage in ROOT                                                                       |
| `IGUANA`                                                 | the path to the Iguana installation prefix, equivalent to `pkg-config iguana --variable prefix`; this is only for consumers that do not use `pkg-config` or the other standard environment variables, however usage of this variable is _discouraged_ since the installation layout may vary |

- also removes the Fortran-specific environment variables, which are currently only used on a testing branch