### PR TITLE
Move to a raw modulefile setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,25 @@
 # clas12-env
 
 ### Overview
-This repository is the environment setup for CLAS12 software.  It leverages modulefiles's prerequisites and conflicts to help ensure a working environment with easy and flexible manipulations.  
-
-*Note, the modulefiles and software builds for GEANT4/GEMC used in this environment are [documented separately](https://geant4.jlab.org/node/1) and can be used independently.*
+This repository is a runtime environment setup for CLAS12 software based on [module](https://modules.sourceforge.net/)[files](https://modules.readthedocs.io/en/latest/modulefile.html).  *The GEANT4/GEMC portions of this environment are [documented here](https://geant4.jlab.org/node/1) and can be used independently.*
 
 ### In Use
-The main branch is deployed on CVMFS and used for running software at JLab, on the Open Science Grid, or on any supported operating system with CVMFS access.  The entry point is:
+The main branch is deployed on CVMFS and used for running software at JLab, on the Open Science Grid, or on any supported operating system with CVMFS access:
 
 `module use /cvmfs/oasis.opensciencegrid.jlab.org/jlab/hallb/clas12/sw/modulefiles`
 
-The documentation for just using these environment modules has so far been [maintained at this wiki](https://clasweb.jlab.org/wiki/index.php/CLAS12_Software_Environment_@_JLab).
-
 ### Special Modules
-Most modules here just update one's environment for a single, particular software package, by adding that package's directory to some runtime executable/library search paths.  The modules below are a bit different.  Remember that `module show` will print what a given module will do to your environment.
+Most modules here just update one's environment for a single, particular software package, by adding that package's directory to some runtime executable/library search path(s).  These modules below are a bit different:
 * clas12
   * loads a bunch of other modules to provide a full CLAS12 environment in one shot
 * geant4
   * adds the [independent geant4-related modulefiles](https://geant4.jlab.org/node/1), e.g. gemc, to the search path
 * tmpfs
-  * sets various envionment variables to get various software (maven, apptainer, java, things that honor `TMPDIR`, etc.) to use a `/tmp` alternative, e.g. for when it's mounted noexec
+  * sets various environment variables to get various software (maven, apptainer, java, things that honor `TMPDIR`, etc.) to use a `/tmp` alternative, e.g. for when it's mounted noexec
+* scicomp
+  * adds software supported by JLab's scicomp group to the module search path
 
-Also, these two modules below are required by many other modules to provide some 3rd-party dependencies.  While no automated recipe currently exists for installation of those dependencies, they require only very standard build and install procedures with no patching.
+And these two modules below provide some 3rd-party dependencies installed in a "system-like" location:
 * system
   * sets `OSRELEASE` based on the operating system (via [this script](util/osrelease.py))
   * sets `CLAS12_HOME` (only for convenience)

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ The main branch is deployed on CVMFS and used for running software at JLab, on t
 `module use /cvmfs/oasis.opensciencegrid.jlab.org/jlab/hallb/clas12/sw/modulefiles`
 
 ### Special Modules
-Most modules here just update one's environment for a single, particular software package, by adding that package's location(s) to some runtime executable/library search path(s).  These modules below are a bit different:
+Most modules update one's environment for a single, particular software package, by adding that package's location(s) to some runtime executable/library search path(s).  These modules are a bit different.
 * clas12
   * loads a bunch of other modules to provide a full CLAS12 environment in one shot
 * geant4
-  * adds the [independent geant4-related modulefiles](https://geant4.jlab.org/node/1), e.g. gemc, to the search path
-* tmpfs
-  * sets various environment variables to get various software (maven, apptainer, java, things that honor `TMPDIR`, etc.) to use a `/tmp` alternative, e.g. for when it's mounted noexec
+  * adds [geant4-related modulefiles](https://geant4.jlab.org/node/1) to the search path
 * scicomp
   * adds software supported by JLab's scicomp group to the module search path
+* tmpfs
+  * sets various environment variables to get various software (maven, apptainer, java, things that honor `TMPDIR`, etc.) to use a `/tmp` alternative, e.g. for when it's mounted noexec
 
 And these two modules below provide some 3rd-party dependencies installed in a "system-like" location:
 * system

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This repository is the environment setup for CLAS12 software.  It leverages modu
 *Note, the modulefiles and software builds for GEANT4/GEMC and its dependencies are maintained separately at [insert link]() and can be used independently.*
 
 ### In Use
-The main branch is deployed on CVMFS and used for running software at JLab, on the Open Science Grid, or on any supported operating system with CVMFS access:
+The main branch is deployed on CVMFS and used for running software at JLab, on the Open Science Grid, or on any supported operating system with CVMFS access.  The entry point is:
 
-`/cvmfs/oasis.opensciencegrid.jlab.org/jlab/hallb/clas12/sw`
+`module use /cvmfs/oasis.opensciencegrid.jlab.org/jlab/hallb/clas12/sw/modulefiles`
 
 The documentation for just using these environment modules has so far been [maintained at this wiki](https://clasweb.jlab.org/wiki/index.php/CLAS12_Software_Environment_@_JLab).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # clas12-env
 
 ### Overview
-This repository is a runtime environment setup for CLAS12 software based on [module](https://modules.sourceforge.net/)[files](https://modules.readthedocs.io/en/latest/modulefile.html).  *The GEANT4/GEMC portions of this environment are [documented here](https://geant4.jlab.org/node/1) and can be used independently.*
+This repository is a runtime environment setup for CLAS12 software based on [module](https://modules.sourceforge.net/)[files](https://modules.readthedocs.io/en/latest/modulefile.html).  The GEANT4/GEMC portions of this environment are [documented here](https://geant4.jlab.org/node/1) and can be used independently.
 
 ### In Use
 The main branch is deployed on CVMFS and used for running software at JLab, on the Open Science Grid, or on any supported operating system with CVMFS access:
@@ -9,7 +9,7 @@ The main branch is deployed on CVMFS and used for running software at JLab, on t
 `module use /cvmfs/oasis.opensciencegrid.jlab.org/jlab/hallb/clas12/sw/modulefiles`
 
 ### Special Modules
-Most modules here just update one's environment for a single, particular software package, by adding that package's directory to some runtime executable/library search path(s).  These modules below are a bit different:
+Most modules here just update one's environment for a single, particular software package, by adding that package's location(s) to some runtime executable/library search path(s).  These modules below are a bit different:
 * clas12
   * loads a bunch of other modules to provide a full CLAS12 environment in one shot
 * geant4

--- a/modulefiles/ccdb/.common
+++ b/modulefiles/ccdb/.common
@@ -5,6 +5,8 @@ prereq pymods
 
 conflict ccdb
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv CCDB_USER $env(USER)
 setenv CCDB_HOME [home]/[osrelease]/local/ccdb/$version
 setenv CCDB_CONNECTION mysql://clas12reader@clasdb-farm.jlab.org/clas12

--- a/modulefiles/ced/.common
+++ b/modulefiles/ced/.common
@@ -1,4 +1,6 @@
 module-whatis https://userweb.jlab.org/~heddle/ced
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PATH [home]/noarch/ced/$version
 

--- a/modulefiles/clara/5.0.2
+++ b/modulefiles/clara/5.0.2
@@ -4,6 +4,8 @@ module-whatis https://claraweb.jlab.org
 
 set clara 5.0.2
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv CLARA_HOME [home]/noarch/clara/${clara}
 prepend-path PATH $env(CLARA_HOME)/bin
 

--- a/modulefiles/clas12root/.common
+++ b/modulefiles/clas12root/.common
@@ -7,6 +7,8 @@ prereq qadb
 prereq hipo
 prereq root
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set v [getvenv HIPO]
 setenv CLAS12ROOT [home]/[osrelease]/local/clas12root/$version/$v
 

--- a/modulefiles/cmake/3.29.0
+++ b/modulefiles/cmake/3.29.0
@@ -2,5 +2,7 @@
 
 set version 3.29.0
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PATH [home]/[osrelease]/local/cmake/$version/bin
 

--- a/modulefiles/coatjava/.common
+++ b/modulefiles/coatjava/.common
@@ -1,5 +1,7 @@
 module-whatis https://github.com/jeffersonlab/coatjava
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv COATJAVA [home]/noarch/coatjava/${coatjava}
 setenv CLAS12DIR [home]/noarch/coatjava/${coatjava}
 setenv CLARA_HOME [home]/noarch/clara/${clara}_${coatjava}

--- a/modulefiles/denoise/.common
+++ b/modulefiles/denoise/.common
@@ -3,6 +3,8 @@ module-whatis https://github.com/gavalian/driftchambers
 prereq system
 prereq hipo
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set v [getvenv HIPO]
 set d [home]/[osrelease]/local/driftchambers/$version/$v
 

--- a/modulefiles/geant4
+++ b/modulefiles/geant4
@@ -2,9 +2,11 @@
 
 module-whatis initialize jlab geant4 modulefiles
 
-setenv SIM_HOME /cvmfs/oasis.opensciencegrid.org/jlab/geant4
-module use -a $env(SIM_HOME)/ceInstall/modulefiles
+source [file dirname $ModulesCurrentModulefile]/../util/functions.tcl
 
 setenv SIM_VERSION 1.0
+setenv SIM_HOME /cvmfs/oasis.opensciencegrid.org/jlab/geant4
 setenv SIM_INSTALLATION_DIR $env(SIM_HOME)/$env(SIM_VERSION)/[osrelease]
+
+module use -a $env(SIM_HOME)/ceInstall/modulefiles
 

--- a/modulefiles/groovy/4.0.20
+++ b/modulefiles/groovy/4.0.20
@@ -1,3 +1,5 @@
 #%Module1.0
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PATH [home]/noarch/groovy/4.0.20/bin

--- a/modulefiles/groovy/4.0.3
+++ b/modulefiles/groovy/4.0.3
@@ -2,5 +2,7 @@
 
 module-whatis https://groovy-lang.org
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PATH [home]/noarch/groovy/4.0.3/bin
 

--- a/modulefiles/hipo/.common
+++ b/modulefiles/hipo/.common
@@ -4,6 +4,8 @@ prereq system
 
 conflict hipo
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv HIPO [home]/[osrelease]/local/hipo/$version
 prepend-path PATH $env(HIPO)/bin
 prepend-path LD_LIBRARY_PATH $env(HIPO)/lib

--- a/modulefiles/iguana/.common
+++ b/modulefiles/iguana/.common
@@ -6,6 +6,8 @@ prereq pymods
 
 conflict iguana
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set v [getvenv HIPO]
 set d [home]/[osrelease]/local/iguana/$version/$v
 

--- a/modulefiles/iguana/0.6.0
+++ b/modulefiles/iguana/0.6.0
@@ -6,6 +6,8 @@ prereq pymods
 
 conflict iguana
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set version 0.6.0
 set v [getvenv HIPO]
 set d [home]/[osrelease]/local/iguana/$version/$v

--- a/modulefiles/jdk/17.0.2
+++ b/modulefiles/jdk/17.0.2
@@ -6,6 +6,8 @@ conflict jdk
 
 set v 17.0.2
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv JAVA_HOME [home]/[osrelease]/jdk/$v
 prepend-path PATH [home]/[osrelease]/jdk/$v/bin
 

--- a/modulefiles/jdk/21.0.2
+++ b/modulefiles/jdk/21.0.2
@@ -4,6 +4,8 @@ module-whatis https://openjdk.org/
 
 set v 21.0.2
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv JAVA_HOME [home]/[osrelease]/local/jdk/$v
 prepend-path PATH [home]/[osrelease]/local/jdk/$v/bin
 

--- a/modulefiles/julia/1.10.2
+++ b/modulefiles/julia/1.10.2
@@ -4,6 +4,8 @@ module-whatis https://www.ruby-lang.org
 
 set v 1.10.2
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PATH [home]/[osrelease]/local/julia/$v/bin
 prepend-path LD_LIBRARY_PATH [home]/[osrelease]/local/julia/$v/lib
 

--- a/modulefiles/maven/3.9.0
+++ b/modulefiles/maven/3.9.0
@@ -5,6 +5,8 @@ conflict maven
 
 set version 3.9.0
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv MAVEN_HOME [home]/noarch/maven/$version
 prepend-path PATH $env(MAVEN_HOME)/bin
 

--- a/modulefiles/maven/3.9.6
+++ b/modulefiles/maven/3.9.6
@@ -5,6 +5,8 @@ conflict maven
 
 set version 3.9.6
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv MAVEN_HOME [home]/noarch/maven/$version
 prepend-path PATH $env(MAVEN_HOME)/bin
 

--- a/modulefiles/mcgen/.common
+++ b/modulefiles/mcgen/.common
@@ -5,6 +5,8 @@ prereq root
 
 conflict mcgen
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set d [home]/[osrelease]/local/clas12-mcgen/$version
 
 prepend-path PATH $d/bin

--- a/modulefiles/mon12/7.2
+++ b/modulefiles/mon12/7.2
@@ -2,5 +2,7 @@
 
 module-whatis https://github.com/jeffersonlab/mon12
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PATH [home]/noarch/mon12/7.2/bin
 

--- a/modulefiles/pymods/3.9
+++ b/modulefiles/pymods/3.9
@@ -6,6 +6,8 @@ prereq system
 
 set v 3.9
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PYTHONPATH [home]/[osrelease]/lib/python$v/site-packages
 prepend-path PYTHONPATH [home]/[osrelease]/lib64/python$v/site-packages
 

--- a/modulefiles/qadb/1.3.0
+++ b/modulefiles/qadb/1.3.0
@@ -4,6 +4,8 @@ module-whatis https://github.com/jeffersonlab/clas12-qadb
 
 set version 1.3.0
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv QADB [home]/noarch/clas12-qadb/$version
 prepend-path JYPATH $env(QADB)/src
 

--- a/modulefiles/rcdb/1.99.0
+++ b/modulefiles/rcdb/1.99.0
@@ -6,6 +6,8 @@ prereq pymods
 
 set v 1.99.0
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv RCDB_HOME [home]/noarch/rcdb/$v
 
 setenv RCDB_CONNECTION mysql://rcdb@clasdb.jlab.org/rcdb 

--- a/modulefiles/root/6.30.04
+++ b/modulefiles/root/6.30.04
@@ -6,6 +6,8 @@ prereq system
 
 conflict root
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set top [home]/[osrelease]/local/root/6.30.04
 
 setenv ROOTSYS $top

--- a/modulefiles/scicomp/auto
+++ b/modulefiles/scicomp/auto
@@ -1,6 +1,7 @@
 #%Module1.0
 
 source [file dirname $ModulesCurrentModulefile]/.common
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
 
 set searched {}
 

--- a/modulefiles/sqlite/.common
+++ b/modulefiles/sqlite/.common
@@ -1,6 +1,8 @@
 prereq ccdb
 prereq rcdb
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 setenv CCDB_CONNECTION sqlite:///[home]/noarch/data/ccdb/ccdb_$version.sqlite
 setenv RCDB_CONNECTION sqlite:///[home]/noarch/data/rcdb/rcdb_$version.sqlite
 

--- a/modulefiles/system
+++ b/modulefiles/system
@@ -2,6 +2,8 @@
 
 module-whatis core environment variables and some common, 3rd party dependencies
 
+source [file dirname $ModulesCurrentModulefile]/../util/functions.tcl
+
 setenv CLAS12_HOME [home]
 setenv OSRELEASE [osrelease]
 

--- a/modulefiles/timeline/dev
+++ b/modulefiles/timeline/dev
@@ -6,6 +6,8 @@ prereq rcdb
 prereq groovy/4.0.3
 prereq coatjava
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set d [home]/noarch/clas12-timeline/dev
 
 prepend-path PATH $d/bin

--- a/modulefiles/tmpfs
+++ b/modulefiles/tmpfs
@@ -2,6 +2,8 @@
 
 module-whatis find an alternative for /tmp (e.g., when it's mounted noexec)
 
+source [file dirname $ModulesCurrentModulefile]/../util/functions.tcl
+
 set failed {}
 
 proc settmp {tmpdir} {

--- a/modulefiles/util/dev
+++ b/modulefiles/util/dev
@@ -6,5 +6,7 @@ prereq ccdb
 prereq rcdb
 prereq pymods
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 prepend-path PATH [home]/noarch/clas12-utilities/dev/bin
 

--- a/modulefiles/workflow/dev
+++ b/modulefiles/workflow/dev
@@ -9,6 +9,8 @@ prereq coatjava
 prereq jdk
 prereq pymods
 
+source [file dirname $ModulesCurrentModulefile]/../../util/functions.tcl
+
 set d [home]/noarch/clas12-workflow/dev
 
 setenv CLAS12WFLOW $d

--- a/setup.csh
+++ b/setup.csh
@@ -32,9 +32,9 @@ endif
 
 if ( ($?clas12_home) && (-d $clas12_home/modulefiles) ) then
     echo "WARNING:  This setup.csh script is deprecated and will be removed in the future:"
-    echo "WARNING:  $clas12_home/setup.csh"
-    echo "WARNING:  This is equivalent and should be used instead:"
-    echo "WARNING:  module use $clas12_home/modulefiles"
+    echo "          $clas12_home/setup.csh"
+    echo "WARNING:  This command is equivalent and should be used instead:"
+    echo "          module use $clas12_home/modulefiles"
     module use $clas12_home/modulefiles
 else
     echo 'ERROR: could not find $CLAS12_HOME.  Note, if you are sourcing this'

--- a/setup.csh
+++ b/setup.csh
@@ -31,8 +31,10 @@ else
 endif
 
 if ( ($?clas12_home) && (-d $clas12_home/modulefiles) ) then
-    echo "WARNING:  This $clas12_home/setup.csh script is deprecated and will be removed by 2025."
-    echo "WARNING:  This is equivalent and should be used instead:  'module use $clas12_home/modulefiles'"
+    echo "WARNING:  This setup.csh script is deprecated and will be removed in the future:"
+    echo "WARNING:  $clas12_home/setup.csh"
+    echo "WARNING:  This is equivalent and should be used instead:"
+    echo "WARNING:  module use $clas12_home/modulefiles"
     module use $clas12_home/modulefiles
 else
     echo 'ERROR: could not find $CLAS12_HOME.  Note, if you are sourcing this'

--- a/setup.csh
+++ b/setup.csh
@@ -38,7 +38,6 @@ if ( ($?clas12_home) && (-d $clas12_home/modulefiles) ) then
 
     # add clas12 modulefiles:
     module use $clas12_home/modulefiles
-    module config extra_siteconfig $clas12_home/util/siteconfig.tcl
 else
     echo 'ERROR: could not find $CLAS12_HOME.  Note, if you are sourcing this'
     echo 'from another tcsh script, you need to either pass the full path as'

--- a/setup.csh
+++ b/setup.csh
@@ -31,11 +31,6 @@ else
 endif
 
 if ( ($?clas12_home) && (-d $clas12_home/modulefiles) ) then
-    # system module initialization for non-login shells:
-    if ( -e /etc/profile.d/modules.csh ) then
-        source /etc/profile.d/modules.csh
-    endif
-
     # add clas12 modulefiles:
     module use $clas12_home/modulefiles
 else

--- a/setup.csh
+++ b/setup.csh
@@ -31,7 +31,8 @@ else
 endif
 
 if ( ($?clas12_home) && (-d $clas12_home/modulefiles) ) then
-    # add clas12 modulefiles:
+    echo "WARNING:  This $clas12_home/setup.csh script is deprecated and will be removed by 2025."
+    echo "WARNING:  This is equivalent and should be used instead:  'module use $clas12_home/modulefiles'"
     module use $clas12_home/modulefiles
 else
     echo 'ERROR: could not find $CLAS12_HOME.  Note, if you are sourcing this'

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,8 @@ fi
 if [ -z ${home+x} ] && [ -d $home/modulefiles ]; then
     echo 'ERROR:  could not find $CLAS12_HOME.'
 else
-    echo "WARNING:  This $home/setup.sh script is deprecated and will be removed by 2025."
-    echo "WARNING:  This is equivalent and should be used instead:  'module use $home/modulefiles'"
-    module use $home/modulefiles
+    echo "WARNING:  This setup.csh script is deprecated and will be removed in the future:"
+    echo "          $home/setup.sh"
+    echo "WARNING:  This command is equivalent and should be used instead:"
+    echo "          module use $home/modulefiles"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -13,11 +13,6 @@ fi
 if [ -z ${home+x} ] && [ -d $home/modulefiles ]; then
     echo 'ERROR:  could not find $CLAS12_HOME.'
 else
-    # system module initialization for non-login shells:
-    if [ -e /etc/profile.d/modules.sh ]; then
-        source /etc/profile.d/modules.sh
-    fi
-
     # add clas12 modulefiles:
     module use $home/modulefiles
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,7 @@ fi
 if [ -z ${home+x} ] && [ -d $home/modulefiles ]; then
     echo 'ERROR:  could not find $CLAS12_HOME.'
 else
-    # add clas12 modulefiles:
+    echo "WARNING:  This $home/setup.sh script is deprecated and will be removed by 2025."
+    echo "WARNING:  This is equivalent and should be used instead:  'module use $home/modulefiles'"
     module use $home/modulefiles
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -20,5 +20,4 @@ else
 
     # add clas12 modulefiles:
     module use $home/modulefiles
-    module config extra_siteconfig $home/util/siteconfig.tcl
 fi


### PR DESCRIPTION
* remove reliance on modulefile's extra_siteconfig
  * only one config file is supported, and it's only settable externally (not from within a modulefile)
  * some negligible performance loss due to resourcing, otherwise just adds import litter
* remove reliance on shell magic (do it in tcl instead)
* leave it to the user to have a working system module environment

So now it's just `module load /path/to/clas12-env/modulefiles`