### PR TITLE
refactor: cleanup `iguana` module files

### DIFF
--- a/modulefiles/iguana/.common
+++ b/modulefiles/iguana/.common
@@ -1,7 +1,7 @@
 module-whatis https://github.com/jeffersonlab/iguana
 
 prereq system
-prereq hipo
+prereq $hipo_prereq
 prereq pymods
 
 conflict iguana

--- a/modulefiles/iguana/.generic
+++ b/modulefiles/iguana/.generic
@@ -1,6 +1,0 @@
-#%Module1.0
-
-set version [file tail [module-info version [module-info name]]]
-
-source [file dirname $ModulesCurrentModulefile]/.common
-

--- a/modulefiles/iguana/0.4.1
+++ b/modulefiles/iguana/0.4.1
@@ -1,20 +1,7 @@
 #%Module1.0
 
-prereq system
-prereq hipo/4.0.1
-prereq pymods
+set version [file tail [module-info version [module-info name]]]
+set hipo_prereq hipo/4.0.1
 
-conflict iguana
+source [file dirname $ModulesCurrentModulefile]/.common
 
-set version 0.4.1
-set v [getvenv HIPO]
-set d [home]/[osrelease]/local/iguana/$version/$v
-
-warndir $d "iguana/$version is not available for hipo/$v"
-
-setenv IGUANA $d
-prepend-path PATH $d/bin
-prepend-path LD_LIBRARY_PATH $d/lib
-prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
-prepend-path PYTHONPATH $d/python
-prepend-path ROOT_INCLUDE_PATH $d/include

--- a/modulefiles/iguana/0.5.0
+++ b/modulefiles/iguana/0.5.0
@@ -1,20 +1,7 @@
 #%Module1.0
 
-prereq system
-prereq hipo@4.1.0,4.0.1
-prereq pymods
+set version [file tail [module-info version [module-info name]]]
+set hipo_prereq hipo@4.1.0,4.0.1
 
-conflict iguana
+source [file dirname $ModulesCurrentModulefile]/.common
 
-set version 0.5.0
-set v [getvenv HIPO]
-set d [home]/[osrelease]/local/iguana/$version/$v
-
-warndir $d "iguana/$version is not available for hipo/$v"
-
-setenv IGUANA $d
-prepend-path PATH $d/bin
-prepend-path LD_LIBRARY_PATH $d/lib
-prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
-prepend-path PYTHONPATH $d/python
-prepend-path ROOT_INCLUDE_PATH $d/include

--- a/modulefiles/iguana/0.6.0
+++ b/modulefiles/iguana/0.6.0
@@ -1,20 +1,7 @@
 #%Module1.0
 
-prereq system
-prereq hipo/4.1.0
-prereq pymods
+set version [file tail [module-info version [module-info name]]]
+set hipo_prereq hipo/4.1.0
 
-conflict iguana
+source [file dirname $ModulesCurrentModulefile]/.common
 
-set version 0.6.0
-set v [getvenv HIPO]
-set d [home]/[osrelease]/local/iguana/$version/$v
-
-warndir $d "iguana/$version is not available for hipo/$v"
-
-setenv IGUANA $d
-prepend-path PATH $d/bin
-prepend-path LD_LIBRARY_PATH $d/lib
-prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
-prepend-path PYTHONPATH $d/python
-prepend-path ROOT_INCLUDE_PATH $d/include

--- a/modulefiles/iguana/dev
+++ b/modulefiles/iguana/dev
@@ -1,1 +1,7 @@
-.generic
+#%Module1.0
+
+set version [file tail [module-info version [module-info name]]]
+set hipo_prereq hipo
+
+source [file dirname $ModulesCurrentModulefile]/.common
+


### PR DESCRIPTION
- set `$version` and `$hipo_prereq` in each, which at the moment is the only difference between the tags
- everyone sources `.common`