### PR TITLE
iguana: 0.7.0

### DIFF
--- a/modulefiles/iguana/.common
+++ b/modulefiles/iguana/.common
@@ -17,3 +17,4 @@ prepend-path LD_LIBRARY_PATH $d/lib
 prepend-path PKG_CONFIG_PATH $d/lib/pkgconfig
 prepend-path PYTHONPATH $d/python
 prepend-path ROOT_INCLUDE_PATH $d/include
+append-path IGUANA_CONFIG_PATH $d/etc/iguana

--- a/modulefiles/iguana/0.4.1
+++ b/modulefiles/iguana/0.4.1
@@ -1,7 +1,0 @@
-#%Module1.0
-
-set version [file tail [module-info version [module-info name]]]
-set hipo_prereq hipo/4.0.1
-
-source [file dirname $ModulesCurrentModulefile]/.common
-

--- a/modulefiles/iguana/0.6.0
+++ b/modulefiles/iguana/0.6.0
@@ -1,7 +1,1 @@
-#%Module1.0
-
-set version [file tail [module-info version [module-info name]]]
-set hipo_prereq hipo/4.1.0
-
-source [file dirname $ModulesCurrentModulefile]/.common
-
+dev

--- a/modulefiles/iguana/0.7.0
+++ b/modulefiles/iguana/0.7.0
@@ -1,0 +1,7 @@
+#%Module1.0
+
+set version [file tail [module-info version [module-info name]]]
+set hipo_prereq hipo/4.1.0
+
+source [file dirname $ModulesCurrentModulefile]/.common
+

--- a/modulefiles/iguana/0.7.0
+++ b/modulefiles/iguana/0.7.0
@@ -1,7 +1,1 @@
-#%Module1.0
-
-set version [file tail [module-info version [module-info name]]]
-set hipo_prereq hipo/4.1.0
-
-source [file dirname $ModulesCurrentModulefile]/.common
-
+dev

--- a/modulefiles/iguana/dev
+++ b/modulefiles/iguana/dev
@@ -1,7 +1,7 @@
 #%Module1.0
 
 set version [file tail [module-info version [module-info name]]]
-set hipo_prereq hipo
+set hipo_prereq hipo/4.1.0
 
 source [file dirname $ModulesCurrentModulefile]/.common
 


### PR DESCRIPTION
iguana/0.7.0 release notes: https://github.com/JeffersonLab/iguana/releases/tag/v0.7.0

- remove `0.4.1`
- `dev` requires `hipo/4.1.0`
- symlink `0.6.0` and the new `0.7.0` to `dev`, since they all need `hipo/4.1.0`
- append path to `IGUANA_CONFIG_PATH`
  - appended, rather than prepended, so that a user-defined path takes the priority)
  - this variable only applies to 0.7+, but it's okay to have it defined for older versions (just will be unused)