### PR TITLE
feat(qadb): prepend `PATH` for `dev` version

### DIFF
--- a/modulefiles/qadb/.generic_no_bin
+++ b/modulefiles/qadb/.generic_no_bin
@@ -7,6 +7,5 @@ set version [file tail [module-info version [module-info name]]]
 source [file dirname $ModulesCurrentModulefile]/../util/functions.tcl
 
 setenv QADB [home]/noarch/clas12-qadb/$version
-prepend-path PATH $env(QADB)/bin
 prepend-path JYPATH $env(QADB)/src
 

--- a/modulefiles/qadb/1.3.0
+++ b/modulefiles/qadb/1.3.0
@@ -1,1 +1,1 @@
-.generic
+.generic_no_bin

--- a/modulefiles/qadb/2.0.0
+++ b/modulefiles/qadb/2.0.0
@@ -1,1 +1,1 @@
-.generic
+.generic_no_bin

--- a/modulefiles/qadb/3.0.0
+++ b/modulefiles/qadb/3.0.0
@@ -1,1 +1,1 @@
-.generic
+.generic_no_bin


### PR DESCRIPTION
The QADB will soon have a script `qadb-info`, to help make accessing the QADB simpler. I only want `bin/` to be in `PATH` for:
- `dev`
- versions _after_ 3.0.0

See https://github.com/JeffersonLab/clas12-qadb/pull/68