### PR TITLE
fix: specify minimum versions in `prereq`, not lists

### DIFF
--- a/modulefiles/clas12root/1.8.5
+++ b/modulefiles/clas12root/1.8.5
@@ -1,7 +1,7 @@
 #%Module1.0
 
-prereq hipo@4.1.0,4.2.0
-prereq qadb@3.0.0,3.1.0
+prereq hipo@4.1.0:
+prereq qadb@3.0.0:
 prereq iguana@0.8.0
 prereq ccdb
 

--- a/modulefiles/iguana/.generic
+++ b/modulefiles/iguana/.generic
@@ -1,6 +1,6 @@
 #%Module1.0
 
-prereq hipo@4.1.0,4.2.0
+prereq hipo@4.1.0:
 
 set version [file tail [module-info version [module-info name]]]
 source [file dirname $ModulesCurrentModulefile]/.common

--- a/modulefiles/iguana/.generic-4.1.0
+++ b/modulefiles/iguana/.generic-4.1.0
@@ -1,6 +1,6 @@
 #%Module1.0
 
-prereq hipo@4.1.0,4.2.0
+prereq hipo@4.1.0:
 
 set version [file tail [module-info version [module-info name]]]
 source [file dirname $ModulesCurrentModulefile]/.common

--- a/modulefiles/iguana/.generic-4.2.0
+++ b/modulefiles/iguana/.generic-4.2.0
@@ -1,6 +1,6 @@
 #%Module1.0
 
-prereq hipo@4.2.0
+prereq hipo@4.2.0:
 
 set version [file tail [module-info version [module-info name]]]
 source [file dirname $ModulesCurrentModulefile]/.common

--- a/modulefiles/iguana/0.5.0
+++ b/modulefiles/iguana/0.5.0
@@ -1,6 +1,6 @@
 #%Module1.0
 
-prereq hipo@4.1.0,4.0.1
+prereq hipo@4.0.1:
 
 set version [file tail [module-info version [module-info name]]]
 source [file dirname $ModulesCurrentModulefile]/.common


### PR DESCRIPTION
Use [version specifiers](https://modules.readthedocs.io/en/latest/modulefile.html#version-specifiers) to set minimum compatible version numbers, which will be much more maintainable than full lists.