### PR TITLE
timeline: remove unnecessary dependencies for timeline v3

### DIFF
--- a/modulefiles/timeline/prod
+++ b/modulefiles/timeline/prod
@@ -3,8 +3,6 @@
 module-whatis https://github.com/jeffersonlab/clas12-timeline
 
 prereq jdk
-prereq groovy
-prereq coatjava
 prereq rcdb
 
 source [file dirname $ModulesCurrentModulefile]/../util/functions.tcl


### PR DESCRIPTION
https://github.com/JeffersonLab/clas12-timeline/pull/293 removes the explicit need for `groovy` and `coatjava` as external dependencies; the Maven build will just copy the necessary JAR files for these, so now the timeline code is much more standalone. RCDB remains as an external dependency. See the PR for reasoning and details.

~~This should not be merged until we have actually deployed v3.~~ ready now